### PR TITLE
Need to pass the entire config object as parameter when creating a migration

### DIFF
--- a/bin/mm
+++ b/bin/mm
@@ -59,7 +59,7 @@
   };
 
   createMigrator = function() {
-    return new Migrator(config.db);
+    return new Migrator(config);
   };
 
   runMigrations = function(opts) {


### PR DESCRIPTION
So I tried to run ../node_modules/.bin/mm create APP-SCHEMA-V2 and got the following error:

> Error: database name must be a string

It turns out that the whole config object has to be passed when creating a Migrator object.

Correct me if I'm wrong.

Thanks!
