### PR TITLE
Printing the error stack on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ non-standard name.
 If you have `.coffee` migration files, `coffee-script >= 1.7.0` package
 must be importable from the current directory.
 
+### Debugging migrations
+
+```bash
+DEBUG=true mm
+```
+
+Running with a `DEBUG=true` will print out the error stack on the console.
+
 ## Programmatic usage
 
 The library also supports programmatic usage.

--- a/bin-src/mm.coffee
+++ b/bin-src/mm.coffee
@@ -4,6 +4,7 @@ fs = require('fs')
 path = require('path')
 optparser = require('nomnom')
 _ = require('lodash')
+debug = !!process.env.DEBUG
 
 mm = require('..')
 Migrator = mm.Migrator
@@ -35,7 +36,7 @@ readConfig = (fileName) ->
       require('coffee-script/register')
     config = _.extend {}, defaults, require(fileName)
   catch e
-    exit fileName + " cannot be imported"
+    exit fileName + " cannot be imported", e
 
 cwd = ->
   path.join dir, config.directory
@@ -54,10 +55,14 @@ createMigration = (opts) ->
     exit "Migration ID is required"
   createMigrator().create cwd(), id, exit, opts.coffee
 
-exit = (err) ->
-  if err
-    console.error "Error: " + err
+exit = (msg, err) ->
+  if debug
+    console.error err.stack
+
+  if msg
+    console.error "Error: " + msg
     process.exit 1
+
   process.exit 0
 
 optparser

--- a/bin-src/mm.coffee
+++ b/bin-src/mm.coffee
@@ -56,14 +56,11 @@ createMigration = (opts) ->
   createMigrator().create cwd(), id, exit, opts.coffee
 
 exit = (msg, err) ->
-  if debug
-    if err and err.stack
-      console.error err.stack
-
   if msg
-    console.error "Error: " + msg
+    console.error "Error: " + msg,
+    if debug and err?.stack
+      console.error err.stack
     process.exit 1
-
   process.exit 0
 
 optparser

--- a/bin-src/mm.coffee
+++ b/bin-src/mm.coffee
@@ -57,7 +57,7 @@ createMigration = (opts) ->
 
 exit = (msg, err) ->
   if msg
-    console.error "Error: " + msg,
+    console.error "Error: " + msg
     if debug and err?.stack
       console.error err.stack
     process.exit 1

--- a/bin-src/mm.coffee
+++ b/bin-src/mm.coffee
@@ -57,7 +57,8 @@ createMigration = (opts) ->
 
 exit = (msg, err) ->
   if debug
-    console.error err.stack
+    if err and err.stack
+      console.error err.stack
 
   if msg
     console.error "Error: " + msg

--- a/bin/mm
+++ b/bin/mm
@@ -81,7 +81,10 @@
 
   exit = function(msg, err) {
     if (msg) {
-      console.error("Error: " + msg, debug && (err != null ? err.stack : void 0) ? console.error(err.stack) : void 0);
+      console.error("Error: " + msg);
+      if (debug && (err != null ? err.stack : void 0)) {
+        console.error(err.stack);
+      }
       process.exit(1);
     }
     return process.exit(0);

--- a/bin/mm
+++ b/bin/mm
@@ -80,13 +80,8 @@
   };
 
   exit = function(msg, err) {
-    if (debug) {
-      if (err && err.stack) {
-        console.error(err.stack);
-      }
-    }
     if (msg) {
-      console.error("Error: " + msg);
+      console.error("Error: " + msg, debug && (err != null ? err.stack : void 0) ? console.error(err.stack) : void 0);
       process.exit(1);
     }
     return process.exit(0);

--- a/bin/mm
+++ b/bin/mm
@@ -81,7 +81,9 @@
 
   exit = function(msg, err) {
     if (debug) {
-      console.error(err.stack);
+      if (err && err.stack) {
+        console.error(err.stack);
+      }
     }
     if (msg) {
       console.error("Error: " + msg);

--- a/bin/mm
+++ b/bin/mm
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 (function() {
-  var Migrator, _, config, createMigration, createMigrator, cwd, defaults, dir, exit, fs, mm, optparser, path, readConfig, runMigrations;
+  var Migrator, _, config, createMigration, createMigrator, cwd, debug, defaults, dir, exit, fs, mm, optparser, path, readConfig, runMigrations;
 
   fs = require('fs');
 
@@ -10,6 +10,8 @@
   optparser = require('nomnom');
 
   _ = require('lodash');
+
+  debug = !!process.env.DEBUG;
 
   mm = require('..');
 
@@ -50,7 +52,7 @@
       return config = _.extend({}, defaults, require(fileName));
     } catch (_error) {
       e = _error;
-      return exit(fileName + " cannot be imported");
+      return exit(fileName + " cannot be imported", e);
     }
   };
 
@@ -77,9 +79,12 @@
     return createMigrator().create(cwd(), id, exit, opts.coffee);
   };
 
-  exit = function(err) {
-    if (err) {
-      console.error("Error: " + err);
+  exit = function(msg, err) {
+    if (debug) {
+      console.error(err.stack);
+    }
+    if (msg) {
+      console.error("Error: " + msg);
       process.exit(1);
     }
     return process.exit(0);


### PR DESCRIPTION
Often faced issues with `migration.js` having errors and the tool not pointing out the exact error. One can just add a `DEBUG=true` when running `mm` to see the error stack.
  
- Added a parameter to the `exit` method
- Added a flag: `process.env.DEBUG`
- Printed the `Error.stack` on `exit` via `console.error`
- Docs added for `DEBUG` flag