### PR TITLE
Support for ssl connection to mongo

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,7 @@
     }
     if (config.password) {
       if (!hasUser) {
-        throw new Error('Password provided but Username is not');
+        throw new Error('Password provided but Username is not - js');
       }
       s += ':' + config.password;
     }
@@ -30,6 +30,10 @@
     s += '/';
     if (config.db) {
       s += config.db;
+    }
+    
+    if(config.ssl) {
+      s += '?ssl=true'
     }
     return s;
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,7 @@
     }
     if (config.password) {
       if (!hasUser) {
-        throw new Error('Password provided but Username is not - js');
+        throw new Error('Password provided but Username is not');
       }
       s += ':' + config.password;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,7 @@
     }
     if (config.password) {
       if (!hasUser) {
-        throw new Error('Password provided but Username is not');
+        throw new Error('Password provided but Username is not - js');
       }
       s += ':' + config.password;
     }

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -12,7 +12,7 @@ buildMongoConnString = (config) ->
 
   if config.password
     if not hasUser
-      throw new Error 'Password provided but Username is not'
+      throw new Error 'Password provided but Username is not coffee'
     s += ':' + config.password
 
   if hasUser

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -12,7 +12,7 @@ buildMongoConnString = (config) ->
 
   if config.password
     if not hasUser
-      throw new Error 'Password provided but Username is not coffee'
+      throw new Error 'Password provided but Username is not'
     s += ':' + config.password
 
   if hasUser

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -12,7 +12,7 @@ buildMongoConnString = (config) ->
 
   if config.password
     if not hasUser
-      throw new Error 'Password provided but Username is not'
+      throw new Error 'Password provided but Username is not coffee'
     s += ':' + config.password
 
   if hasUser
@@ -27,6 +27,9 @@ buildMongoConnString = (config) ->
 
   if config.db
     s += config.db
+
+  if config.ssl
+    s += '?ssl=true'
 
   return s
 


### PR DESCRIPTION
Added ssl query parameter in the connection string while connecting securely to the mongo db.
This option can be configured by passing ssl option in the config file. The datatype of that option should be boolean.
**Example:** `ssl: true`