### PR TITLE
Added support for custom MongoDB.Client options

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,21 +1,21 @@
 (function() {
-  var DEFAULT_POOL_SIZE, MongoClient, urlBuilder;
+  var DEFAULT_POOL_SIZE, MongoClient, _, urlBuilder;
 
   MongoClient = require('mongodb').MongoClient;
 
   urlBuilder = require('./url-builder');
 
+  _ = require('lodash');
+
   DEFAULT_POOL_SIZE = 5;
 
   exports.connect = function(config, cb) {
-    var poolSize, ref, url;
+    var options, poolSize, ref, url;
     poolSize = (ref = config.poolSize) != null ? ref : DEFAULT_POOL_SIZE;
     url = urlBuilder.buildMongoConnString(config);
-    return MongoClient.connect(url, {
-      server: {
-        poolSize: poolSize
-      }
-    }, cb);
+    options = config.options || {};
+    _.set(options, 'server.poolSize', poolSize);
+    return MongoClient.connect(url, options, cb);
   };
 
   exports.repeatString = function(str, n) {

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -1,5 +1,6 @@
 MongoClient = require('mongodb').MongoClient
 urlBuilder = require('./url-builder')
+_ = require('lodash')
 
 DEFAULT_POOL_SIZE = 5
 
@@ -7,7 +8,10 @@ exports.connect = (config, cb) ->
   poolSize = config.poolSize ? DEFAULT_POOL_SIZE
 
   url = urlBuilder.buildMongoConnString(config)
-  MongoClient.connect url, { server: { poolSize } }, cb
+  options = config.options || {}
+  _.set(options, 'server.poolSize', poolSize)
+
+  MongoClient.connect url, options, cb
 
 exports.repeatString = (str, n) ->
   Array(n + 1).join(str)


### PR DESCRIPTION
To be able to set MongoDB Client 'mongos' options, added support for providing 'config.options' value with any custom options.
