### PR TITLE
Override default mongo socket timeout of 30 sec

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,13 +8,19 @@
   DEFAULT_POOL_SIZE = 5;
 
   exports.connect = function(config, cb) {
-    var poolSize, ref, url;
+    var poolSize, ref, socketTimeoutMS, url;
     poolSize = (ref = config.poolSize) != null ? ref : DEFAULT_POOL_SIZE;
+
+    // Default to infinite read timeout for mongo operations. (mongodb default
+    // is 30 sec)
+    socketTimeoutMS = (ref = config.socketTimeoutMS) != null ? ref : 0;
+
     url = urlBuilder.buildMongoConnString(config);
     return MongoClient.connect(url, {
       server: {
         poolSize: poolSize
-      }
+      },
+      socketTimeoutMS: 0
     }, cb);
   };
 


### PR DESCRIPTION
mongodb-migrations has its own timeout mechanism so the mongo default read timeout is redundant, and breaks when running large operations like index creation.

This doesn't touch the default mongo connect timeout, only the socket read timeout that applies when waiting for a mongo response.