### PR TITLE
runFromDir no longer takes .map files

### DIFF
--- a/lib/mongodb-migrations.js
+++ b/lib/mongodb-migrations.js
@@ -244,6 +244,8 @@
             };
           }).filter(function(f) {
             return !!f.name;
+          }).filter(function(f) {
+            return !f.name.match(/\.map$/);
           }).sort(function(f1, f2) {
             return f1.number - f2.number;
           }).map(function(f) {


### PR DESCRIPTION
Actually, the migration does not work if there is .map file in migration directory.

Not really an issue in production environment but it is one in dev env.