### PR TITLE
Allow setting authentication database in the MongoClient connection via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.5
+
+* Added support for setting authentication database via the `authSource` string.
+
 ## 0.8.4
 
 * Migration files other than `.js` and `.coffee` **will be skipped**, along with dotfiles

--- a/README.md
+++ b/README.md
@@ -73,13 +73,14 @@ from the current directory (include it as your project's dependency).
 
 The configuration object can have the following keys:
 
-* `url` — full MongoDB connection url (_optional_, when used the rest of the connection params (`host`, `port`, `db`, `user`, `password`, `replicaset`) are ignored),
+* `url` — full MongoDB connection url (_optional_, when used the rest of the connection params (`host`, `port`, `db`, `user`, `password`, `replicaset`, `authDatabase`) are ignored),
 * `host` — MongoDB host (_optional_ when using `url` or `replicaset`, **required** otherwise),
 * `port` _[optional]_ — MongoDB port,
 * `db` — MongoDB database name,
 * `ssl` _[optional]_ - boolean, if `true`, `'?ssl=true'` is added to the MongoDB URL,
 * `user` _[optional]_ — MongoDB user name when authentication is required,
 * `password` _[optional]_ — MongoDB password when authentication is required,
+* `authDatabase` _[optional]_ - MongoDB database to authenticate the user against,    
 * `collection` _[optional]_ — The name of the MongoDB collection to track already ran migrations, **defaults to `_migrations`**,
 * `directory` — the directory (path relative to the current folder) to store migration files in and read them from, used when running from the command-line or when using `runFromDir`,
 * `timeout` _[optional]_ — time in milliseconds after which migration should fail if `done()` is not called (use 0 to disable timeout)

--- a/lib/url-builder.js
+++ b/lib/url-builder.js
@@ -45,13 +45,13 @@
       }
       params = [];
       if (replicaset) {
-        params.push('replicaSet=' + replicaset.name);
+        params.push("replicaSet=" + replicaset.name);
       }
       if (config.ssl) {
         params.push('ssl=true');
       }
       if (config.authDatabase) {
-        params.push('authSource=' + config.authDatabase);
+        params.push("authSource=" + config.authDatabase);
       }
       if (params.length > 0) {
         s += '?' + params.join('&');

--- a/lib/url-builder.js
+++ b/lib/url-builder.js
@@ -50,6 +50,9 @@
       if (config.ssl) {
         params.push('ssl=true');
       }
+      if (config.authDatabase) {
+        params.push('authSource=' + config.authDatabase);
+      }
       if (params.length > 0) {
         s += '?' + params.join('&');
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,6 +61,9 @@
     if (config.password && !config.user) {
       throw new Error('`password` provided but `user` is not');
     }
+    if (config.authDatabase && !config.user) {
+      throw new Error('`authDatabase` provided but `user` is not');
+    }
   };
 
   exports.normalizeConfig = function(config) {

--- a/src/url-builder.coffee
+++ b/src/url-builder.coffee
@@ -45,6 +45,9 @@ module.exports =
     if config.ssl
       params.push 'ssl=true'
 
+    if config.authDatabase
+      params.push 'authSource=' + config.authDatabase
+
     if params.length > 0
       s += '?' + params.join('&')
 

--- a/src/url-builder.coffee
+++ b/src/url-builder.coffee
@@ -40,13 +40,13 @@ module.exports =
     params = []
 
     if replicaset
-      params.push 'replicaSet=' + replicaset.name
+      params.push "replicaSet=#{replicaset.name}"
 
     if config.ssl
       params.push 'ssl=true'
 
     if config.authDatabase
-      params.push 'authSource=' + config.authDatabase
+      params.push "authSource=#{config.authDatabase}"
 
     if params.length > 0
       s += '?' + params.join('&')

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -50,6 +50,9 @@ validateConnSettings = (config) ->
   if config.password and not config.user
     throw new Error('`password` provided but `user` is not')
 
+  if config.authDatabase and not config.user
+    throw new Error('`authDatabase` provided but `user` is not')
+
 exports.normalizeConfig = (config) ->
   if not (_.isObject(config) and not _.isArray(config))
     throw new Error('`config` is not provided or is not an object')

--- a/test/url-builder.coffee
+++ b/test/url-builder.coffee
@@ -42,6 +42,22 @@ describe 'Url Builder', ->
       '/' + config.db + '?ssl=true'
     done()
 
+  it 'builds a single node url with an authDatabase', (done) ->
+    config =
+      user: 'someuser'
+      password: 'somepass'
+      host: 'abcde',
+      port: 27111
+      db: '_mm'
+      collection: '_migrations',
+      authDatabase: 'admin'
+
+    connString = urlBuilder.buildMongoConnString config
+    connString.should.be.equal 'mongodb://' + config.user + ':' +
+      config.password + '@' + config.host + ':' + config.port +
+      '/' + config.db + '?authSource=' + config.authDatabase
+    done()
+
   it 'builds a replicaset url with two replicas', (done) ->
     config =
       user: 'someuser'

--- a/test/url-builder.coffee
+++ b/test/url-builder.coffee
@@ -21,9 +21,8 @@ describe 'Url Builder', ->
       collection: '_migrations'
 
     connString = urlBuilder.buildMongoConnString config
-    connString.should.be.equal 'mongodb://' + config.user + ':' +
-      config.password + '@' + config.host + ':' + config.port +
-      '/' + config.db
+    connString.should.be.equal "mongodb://#{config.user}:#{config.password}@" +
+      "#{config.host}:#{config.port}/#{config.db}"
     done()
 
   it 'builds a single node url with ssl', (done) ->
@@ -37,9 +36,8 @@ describe 'Url Builder', ->
       ssl: true
 
     connString = urlBuilder.buildMongoConnString config
-    connString.should.be.equal 'mongodb://' + config.user + ':' +
-      config.password + '@' + config.host + ':' + config.port +
-      '/' + config.db + '?ssl=true'
+    connString.should.be.equal "mongodb://#{config.user}:#{config.password}@" +
+      "#{config.host}:#{config.port}/#{config.db}?ssl=true"
     done()
 
   it 'builds a single node url with an authDatabase', (done) ->
@@ -53,9 +51,8 @@ describe 'Url Builder', ->
       authDatabase: 'admin'
 
     connString = urlBuilder.buildMongoConnString config
-    connString.should.be.equal 'mongodb://' + config.user + ':' +
-      config.password + '@' + config.host + ':' + config.port +
-      '/' + config.db + '?authSource=' + config.authDatabase
+    connString.should.be.equal "mongodb://#{config.user}:#{config.password}@" +
+      "#{config.host}:#{config.port}/#{config.db}?authSource=#{config.authDatabase}"
     done()
 
   it 'builds a replicaset url with two replicas', (done) ->
@@ -78,12 +75,10 @@ describe 'Url Builder', ->
       collection: '_migrations'
 
     connString = urlBuilder.buildMongoConnString config
-    connString.should.be.equal 'mongodb://' + config.user + ':' +
-      config.password + '@' +
-      config.replicaset.members[0].host + ':' + config.replicaset.members[0].port +
-      ',' +
-      config.replicaset.members[1].host + ':' + config.replicaset.members[1].port +
-      '/' + config.db + '?replicaSet=' + config.replicaset.name
+    connString.should.be.equal "mongodb://#{config.user}:#{config.password}@" +
+      "#{config.replicaset.members[0].host}:#{config.replicaset.members[0].port}," +
+      "#{config.replicaset.members[1].host}:#{config.replicaset.members[1].port}/" +
+      "#{config.db}?replicaSet=#{config.replicaset.name}"
     done()
 
   it 'builds a replicaset url with three replicas', (done) ->
@@ -110,12 +105,9 @@ describe 'Url Builder', ->
       collection: '_migrations'
 
     connString = urlBuilder.buildMongoConnString config
-    connString.should.be.equal 'mongodb://' + config.user + ':' +
-      config.password + '@' +
-      config.replicaset.members[0].host + ':' + config.replicaset.members[0].port +
-      ',' +
-      config.replicaset.members[1].host + ':' + config.replicaset.members[1].port +
-      ',' +
-      config.replicaset.members[2].host + ':' + config.replicaset.members[2].port +
-      '/' + config.db + '?replicaSet=' + config.replicaset.name
+    connString.should.be.equal "mongodb://#{config.user}:#{config.password}@" +
+      "#{config.replicaset.members[0].host}:#{config.replicaset.members[0].port}," +
+      "#{config.replicaset.members[1].host}:#{config.replicaset.members[1].port}," +
+      "#{config.replicaset.members[2].host}:#{config.replicaset.members[2].port}/" +
+      "#{config.db}?replicaSet=#{config.replicaset.name}"
     done()

--- a/test/util.coffee
+++ b/test/util.coffee
@@ -154,3 +154,11 @@ describe 'Utils', ->
                 password: 'very secret password'
             }).should.throw('`password` provided but `user` is not')
             done()
+
+        it 'should throw with authDatabase but without username', (done) ->
+            normalizeConfig.bind(null, {
+                host: 'localhost',
+                db: '_mm',
+                authDatabase: 'admin'
+            }).should.throw('`authDatabase` provided but `user` is not')
+            done()


### PR DESCRIPTION
@emirotin pretty cool work here! I like how there's not much bloat in here compared to other migration frameworks. Please review this PR when you find the time.

#### Description

Adds an option to allow setting of the mongodb authentication database via the config file. This resolves an issue where the MongoClient cannot connect to an authentication-enabled mongo instance because the user is stored on a separate authentication database. Achieved by simply appending `authSource` to the connection string

An alternative work around to the issue is to set the `authSource` directly in the url string but this sort of defeats the purpose of having the rest of the JSON file so may as well add this in.

#### References

* Mongo AuthDatabase reference - https://docs.mongodb.com/manual/core/security-users/#user-authentication-database
* Mongo Nodejs driver: https://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html#auth-options

#### Risks

* [Pretty low] Basically just appends a new connection string query parameter