### PR TITLE
Ignore files in the migration directory other than .js and .coffee.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Migration files other than `.js` and `.coffee` **will be skipped**, along with dotfiles
+
 ## 0.8.3
 
 * The new `dedupe` command. Run it once (`mm dedupe` with optional `--config` parameter as usual)

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ The files must conform to the following rules:
 1. be CommonJS modules and export `id`, `up` _[optional]_,
 and `down` _[optional]_ — see [Creating Migrations](#creating-migrations)
 for explanation,
+1. have filenames ending in `.js` or `.coffee`;
 1. if the migration file has `.coffee` extension, the
 `coffee-script >= 1.7.0` package must be importable
 from the current directory.

--- a/lib/mongodb-migrations.js
+++ b/lib/mongodb-migrations.js
@@ -242,7 +242,10 @@
           if (err) {
             return cb(err);
           }
-          files = files.map(function(f) {
+          files = files.filter(function(f) {
+            var ref1;
+            return ((ref1 = path.extname(f)) === '.js' || ref1 === '.coffee') && !f.startsWith('.');
+          }).map(function(f) {
             var n, ref1;
             n = (ref1 = f.match(/^(\d+)/)) != null ? ref1[1] : void 0;
             if (n) {

--- a/src/mongodb-migrations.coffee
+++ b/src/mongodb-migrations.coffee
@@ -176,6 +176,8 @@ class Migrator
         if err
           return cb err
         files = files
+          .filter (f) ->
+            path.extname(f) in ['.js', '.coffee'] && !f.startsWith('.')
           .map (f) ->
             n = f.match(/^(\d+)/)?[1]
             if n

--- a/src/mongodb-migrations.coffee
+++ b/src/mongodb-migrations.coffee
@@ -177,7 +177,7 @@ class Migrator
           return cb err
         files = files
           .filter (f) ->
-            path.extname(f) in ['.js', '.coffee'] && !f.startsWith('.')
+            path.extname(f) in ['.js', '.coffee'] and not f.startsWith('.')
           .map (f) ->
             n = f.match(/^(\d+)/)?[1]
             if n

--- a/test/fromdir.coffee
+++ b/test/fromdir.coffee
@@ -28,7 +28,7 @@ describe 'Migrator from Directory', ->
 
           coll.find({ok: 1}).count (err, count) ->
             return done(err) if err
-            count.should.be.equal 2
+            count.should.be.equal 3
 
             migrator.rollback (err, res) ->
               return done(err) if err

--- a/test/migrations/.should_be_ignored_dotfile.js
+++ b/test/migrations/.should_be_ignored_dotfile.js
@@ -1,0 +1,1 @@
+This file tests the filename extension whitelist in runFromDir.

--- a/test/migrations/4-runFromDir-should-find-coffee.coffee
+++ b/test/migrations/4-runFromDir-should-find-coffee.coffee
@@ -1,4 +1,4 @@
-module.exports.id = "4-test4"
+module.exports.id = "runFromDir-should-find-coffee"
 
 module.exports.up = (done) ->
   @db.collection('test').insert({ name: '123', ok: 1 }, done);

--- a/test/migrations/4-test4.coffee
+++ b/test/migrations/4-test4.coffee
@@ -1,0 +1,4 @@
+module.exports.id = "4-test4"
+
+module.exports.up = (done) ->
+  @db.collection('test').insert({ name: '123', ok: 1 }, done);

--- a/test/migrations/should_be_ignored.not_js
+++ b/test/migrations/should_be_ignored.not_js
@@ -1,0 +1,1 @@
+This file tests the filename extension whitelist in runFromDir.

--- a/test/migrations/should_be_ignored_no_extension
+++ b/test/migrations/should_be_ignored_no_extension
@@ -1,0 +1,1 @@
+This file tests the filename extension whitelist in runFromDir.

--- a/test/rollback.coffee
+++ b/test/rollback.coffee
@@ -22,7 +22,7 @@ describe 'Migrator Rollback', ->
       return done(err) if err
       migrationsCol.find().count (err, count) ->
         return done(err) if err
-        count.should.be.equal 3
+        count.should.be.equal 4
         migrator.rollback (err, res) ->
           return done(err) if err
           coll.find().count (err, count) ->


### PR DESCRIPTION
As per discussion in #28. This skips vim swapfiles, .map files, etc.