### PR TITLE
Fix `mm down --migrations ...` to rollback properly

### DIFF
--- a/bin-src/mm.coffee
+++ b/bin-src/mm.coffee
@@ -65,7 +65,7 @@ runSpecificUp = (opts) ->
 
 runDown = (opts) ->
   if opts.migrations
-    return runSpecificUp(opts)
+    return runSpecificDown(opts)
   createRunner(opts).runDownFromDir cwd(), exit
 
 runSpecificDown = (opts) ->

--- a/bin/mm
+++ b/bin/mm
@@ -92,7 +92,7 @@
 
   runDown = function(opts) {
     if (opts.migrations) {
-      return runSpecificUp(opts);
+      return runSpecificDown(opts);
     }
     return createRunner(opts).runDownFromDir(cwd(), exit);
   };


### PR DESCRIPTION
`mm down --migrations ...` invokes `runSpecificUp()` instead of
`runSpecificDown()`, that is not an intended behavior.